### PR TITLE
Renommer Contribuer.md en contribuer.md

### DIFF
--- a/contribuer.md
+++ b/contribuer.md
@@ -14,7 +14,7 @@ Rendez-vous sur la page [GitHub du Wiki](https://github.com/discordfr/wiki) puis
 
 ![Choisir un Fichier](https://i.discord.fr/X6T.png)
 :::note Note
-Les fichiers portent le nom du lien, par exemple Contribuer.md est le fichier correspondant au lien https://discord.fr/wiki/contribuer.
+Les fichiers portent le nom du lien, par exemple contribuer.md est le fichier correspondant au lien https://discord.fr/wiki/contribuer.
 :::
 
 #### Débuter la modification


### PR DESCRIPTION
**L'intégralité des noms de fichiers du repo sont en minuscule**, à l'exception du fichier `Contribuer.md`, ce qui fait un peu tâche avec le reste. Je propose donc de le renommer `contribuer.md` (sans majuscule), afin de suivre le nommage des autres fichiers.
Il serait également bien de définir des règles strictes concernent ce nommage de fichiers.