### PR TITLE
Update abonnements-nitro.md

### DIFF
--- a/contenu-payant/abonnements-nitro.md
+++ b/contenu-payant/abonnements-nitro.md
@@ -16,22 +16,21 @@ Les abonnements [Nitro](https://support.discord.com/hc/fr/articles/115000435108-
 
 ![Capture Nitro](https://i.discord.fr/bRo.png)
 
-## Nitro Classic ($4,99 par mois / $49,99 par an)
-Nitro Classic était pendant très longtemps le seul abonnement. Désormais, il est l'abonnement "basique" de Discord Nitro.
+## Nitro Basic ($2,99 par mois / $29,99 par an)
+Nitro Basic était pendant très longtemps le seul abonnement. Désormais, il est l'abonnement "basique" de Discord Nitro.
 
 L'abonnement octroie des avantages supplémentaires, comme : 
-* Utilisation des GIF en avatar
-* Choisir son discriminant Discord
-* Qualité de partage d'écran améliorée
-* Partage de fichiers de 8Mo à 50Mo
+* Émojis personnalisés et animés partout
+* Autocollants personnalisés partout et 300 autocollants Nitro
+* Partage de fichiers plus important (limite de 50 Mo)
 * Badge sur le profil de l'utilisateur
-* -30% sur l'achat de boost
+* Super réactions (deux par semaine)
 
 ## Nitro ($9,99 par mois / $99,99 par an)
 Nitro est l'abonnement le plus utilisé, avec le plus de bénéfices.
 
 Encore une fois, il y a des avantages supplémentaires, comme :
-* Tous les avantages de Nitro Classic
+* Tous les avantages de Nitro Basic
 * Partage de fichiers de 8Mo à ~~50Mo~~ 100Mo
 * Partage d'écran à la source
 * Deux boosts de serveur inclus (voir [ici](https://discord.fr/wiki/nitro-jeux/boost-serveur/boost))
@@ -40,7 +39,7 @@ Encore une fois, il y a des avantages supplémentaires, comme :
 * La limite du nombre de serveurs pouvant être rejoint double pour atteindre 200
 * 300 stickers exclusifs à Nitro et la possibilité d'utiliser les stickers personnalisés sur n'importe où.
 * Pouvoir choisir une photo de profil, une bannière et une descripion par serveur.
-
+* Pouvoir modifier son discriminant Discord
 :::note 
 Si un utilisateur est présent sur plus de 100 serveurs à la fin de son abonnement Discord Nitro, il restera sur tous les serveurs sur lesquels il est. Il lui sera toutefois impossible d'en rejoindre ou d'en créer davantage tant qu'il ne sera pas redescendu en dessous de cette limite. 
 :::


### PR DESCRIPTION
<!--
    Informations:
    En ouvrant cette pull request, je m'engage à lire et à respecter les règles suivantes:

    - Toute Pull Request ne suivant pas la template proposée sera fermée sans préavis
    - Les sources abordées dans les articles doivent être vérifiées et pertinentes
    - Le style de rédaction de Discord.FR et les règles orthographiques françaises doivent être respectés.
  
    MERCI DE NE PAS ENLEVER CE COMMENTAIRE
    -->

**Quel est votre identifiant Discord ?**<br/> 
IDD : 992619258964086917

<!-- Pour trouver votre identifiant, vous pouvez suivre ce tutoriel: https://dfr.gd/id -->

**Décrivez rapidement vos ajouts ou changements**<br/>

- Alors dans ce wiki concernant l'abonnement Nitro, j'ai modifié le paragraphe qui concernait l'ancien abonnement "Nitro Classic" et ait remplacé le terme par "Basic". Les avantages ayant changé, ils n'étaient pas à jour, je les ai donc modifiés. Tout comme les prix qui y figuraient, il s'agissait en fin de compte des anciens. (l.19 à l.27). J'ai supprimé la réduction de -30% sur les boosts (anciennement l.27 quelque chose comme ça il me semble que j'ai remplacé par les super réactions qui n'y figuraient pas) lorsque l'on souscrit à un abonnement à $2,99 (je ne suis pas sûr, c'est à vérifier). Et j'ai aussi rajouté l.42 la possibilité de modifier son tag discord, ce que l'on ne peut plus faire avec le nouvel abonnement "Nitro Basic".

- Voici un article officiel de Discord.com qui m'a permis de mettre à jour votre wiki : 

https://support.discord.com/hc/fr/articles/115000435108-Qu-est-ce-que-Nitro-et-Nitro-Basic-#h_01GW0T2SYXR51NKK01NB5NEH80
