### PR TITLE
Fix markdown.mdx

### DIFF
--- a/interface/salons-textuels/markdown.mdx
+++ b/interface/salons-textuels/markdown.mdx
@@ -423,6 +423,6 @@ Plusieurs boutons apparaîtront alors afin de mettre en forme le texte :
 Plusieurs raccourcis claviers sont disponible pour gagner du temps lors de la mise en forme.
 Pour les utiliser il suffit de sélectionner le texte à mettre forme et effectuer une combinaison de touche comme suit :
 
-- <kbd>Ctrl</kbd> + <kbd>I</kbd> : *Italique*
-- <kbd>Ctrl</kbd> + <kbd>B</kbd> : **Gras**
-- <kbd>Ctrl</kbd> + <kbd>U</kbd> : <u>Souligné</u>
+- <kbd>Ctrl</kbd> + <kbd>I</kbd> : \*<i>Italique</i>\*
+- <kbd>Ctrl</kbd> + <kbd>B</kbd> : \*\*<b>Gras</b>\*\*
+- <kbd>Ctrl</kbd> + <kbd>U</kbd> : \_\_<u>Souligné</u>\_\_


### PR DESCRIPTION
<!--
    Informations:
    En ouvrant cette pull request, je m'engage à lire et à respecter les règles suivantes:

    - Toute Pull Request ne suivant pas la template proposée sera fermée sans préavis
    - Les sources abordées dans les articles doivent être vérifiées et pertinentes
    - Le style de rédaction de Discord.FR et les règles orthographiques françaises doivent être respectés.
  
    MERCI DE NE PAS ENLEVER CE COMMENTAIRE
    -->

**Quel est votre identifiant Discord ?**

589383722759880705

**Décrivez rapidement vos ajouts ou changements**

Fix sur les raccourcis clavier : le soulignage apparaissait alors que le gras et l'italique non.
> https://dfr.gg/wiki/interface/salons-textuels/markdown#raccourcis
